### PR TITLE
Fix minor typos in menu

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,12 +2,12 @@ import streamlit
 import pandas
 
 streamlit.title("My Parents New Healthy Dinner")
-print(" ") 
-streamlit.header("BreakFast Menu")
+streamlit.write("")
+streamlit.header("Breakfast Menu")
 streamlit.text("🥣 Omega 3 & Blue Berry Oat meal")
 streamlit.text("🥗 Kale, Spinach & Rocket Smoothie")
 streamlit.text("🐔 Hard Boiled free Range Egg")
-streamlit.text("🥑🍞 Avacado Toast")
+streamlit.text("🥑🍞 Avocado Toast")
 
 streamlit.header('🍌🥭 Build Your Own Fruit Smoothie 🥝🍇')
 


### PR DESCRIPTION
## Summary
- fix typos in breakfast menu header and items
- replace console `print` call with `streamlit.write` for spacing

## Testing
- `python3 -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68599eae0e50832abc49b9264847d1a0